### PR TITLE
実行環境用のコンテナイメージの作成

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -4,6 +4,11 @@ services:
     build:
       context: "./golang"
       dockerfile: "Dockerfile"
+    environment:
+      DB_USER: test
+      DB_PASS: test
+      DB_PATH: postgres
+      DB_NAME: qiita
     ports:
       - "9000:9000"
     command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.devcontainer
+.vscode
+pkg
+document

--- a/.github/workflows/container_create.yml
+++ b/.github/workflows/container_create.yml
@@ -1,0 +1,24 @@
+name: Container Create(Build & Push)
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  DOCKER_USER: ${{secrets.DOCKER_USER}}
+  DOCKER_ACCESS_TOKEN: ${{secrets.DOCKER_ACCESS_TOKEN}}
+  IMAGE: article-backend
+
+jobs:
+  container-create:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Container build & Push
+        run: |
+          docker login --username $DOCKER_USER --password $DOCKER_ACCESS_TOKEN
+          IMAGE_TAG=$(echo ${{ github.ref }} | sed -e "s#refs/tags/v##g")
+          docker build -t $DOCKER_USER/$IMAGE:$IMAGE_TAG -t $DOCKER_USER/$IMAGE:latest .
+          docker push $DOCKER_USER/$IMAGE:$IMAGE_TAG
+          docker push $DOCKER_USER/$IMAGE:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Step1: build
+FROM golang:1.15.0-alpine3.12 as build-step
+
+RUN apk add --update --no-cache ca-certificates git
+
+RUN mkdir /article
+WORKDIR /article
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o /go/bin/article
+
+# Step2: exec
+FROM scratch
+
+ENV DB_USER ""
+ENV DB_PASS ""
+ENV DB_PATH ""
+ENV DB_NAME ""
+
+COPY --from=build-step /go/bin/article /go/bin/article
+ENTRYPOINT ["/go/bin/article"]

--- a/db/postgres/postgres.go
+++ b/db/postgres/postgres.go
@@ -1,6 +1,8 @@
 package postgres
 
 import (
+	"os"
+
 	"github.com/jinzhu/gorm"
 	"github.com/qiitacopy/article/article"
 
@@ -35,6 +37,13 @@ func (p *Postgres) GetByID(id int) (*article.Article, error) {
 
 // gromConnect : postgresに接続する
 func gormConnect() (*gorm.DB, error) {
-	db, err := gorm.Open("postgres", "postgres://test:test@postgres:5432/qiita?sslmode=disable")
+	// 環境変数の取得
+	user := os.Getenv("DB_USER")
+	pass := os.Getenv("DB_PASS")
+	path := os.Getenv("DB_PATH")
+	dbname := os.Getenv("DB_NAME")
+	dbconnection := "postgres://" + user + ":" + pass + "@" + path + ":5432/" + dbname + "?sslmode=disable"
+
+	db, err := gorm.Open("postgres", dbconnection)
 	return db, err
 }

--- a/document/development-environment.md
+++ b/document/development-environment.md
@@ -27,6 +27,13 @@ TODO(後で頑張るかも)
 4. `grpc_cli ls localhost:9000 grpc.ArticleService -l` コマンドで登録されたgRPCのサービスが確認できる
 5. `grpc_cli call localhost:9000 GetByID "id: 1"` コマンドでgRPCのサービスをコマンドラインで呼び出せる
 
+## パイプラインの起動
+本リポジトリではコンテナをビルドし、DockerhubへPUSHを行うパイプラインが構築されている  
+このパイプラインは以下のコマンドでバージョンのタグをつけた際に実行される  
+バージョンの付け方のネーミングルールは先頭にvを付け、その後にMAJOR.MINOR.PATCHを付けるセマンティックバージョニングを採用する  
+1. `git tag -a vX.X.X -m "comment" commitID`
+2. `git push origin vX.X.X`
+
 ## 開発環境更新に関するルール
 ### VSCodeで用いる開発用の外部ライブラリのインストール
 GOPATHを`/workspace`で設定しているため、コンテナ起動後にGUI等でインストールしようとすると、`/workspace/bin`配下にダウンロードされる  


### PR DESCRIPTION
フロントエンド側を作る際に、開発用の共有のバックエンドサーバがあると楽なので作ります。

このブランチでやった変更は以下の通り
* 実行環境のコンテナイメージの作成(実行環境用のコンテナは最低限のバイナリだけにしています)
* コンテナイメージ用のバージョンタグがつけられた際にBuild&Pushするパイプラインを作成
* DBの接続情報を環境変数化(とりあえずベタ書きですが、他に良い方法があれば...)